### PR TITLE
Fix misaligned spinner arm on Safari

### DIFF
--- a/loadingSpinner.scss
+++ b/loadingSpinner.scss
@@ -30,10 +30,8 @@ $vui-loading-spinner-color: #cccccc !default;
 		position: absolute;
 		width: $thickness;
 		height: $halfSize;
-		left: 48%; // For browsers that don't support calc
-		top: 48%; // For browsers that don't support calc
-		left: calc( 50% - #{$halfThickness} );
-		top: calc( 50% - #{$halfThickness} );
+		left: $halfSize - 1.5 * $thickness;
+		top: $halfSize - 1.5 * $thickness;
 
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vui-loading-spinner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Mixins and CSS for styling loading spinner",
   "scripts": {
     "clean": "rimraf *.css",


### PR DESCRIPTION
Use SASS to remove the need for calc, fixing the spinner on Safari 6